### PR TITLE
feat: added aws-announcer repository

### DIFF
--- a/_repositories.auto.tfvars
+++ b/_repositories.auto.tfvars
@@ -5,6 +5,7 @@ repositories = {
     is_template = true
   }
 
+  "aws-announcer"         = { description = "Terraform module for deploying a AWS serverles notifications center to send messages in multiple communication channels" }
   "aws-cicd"              = { description = "Terraform module for deploying AWS CICD resources" }
   "aws-cognito-userpool"  = { description = "Terraform module for deploying AWS Cognito Userpool resources" }
   "aws-dns"               = { description = "Terraform module for deploying AWS Route53 resources" }


### PR DESCRIPTION
Added aws-announcer repository for hosting terraform module for deploying a AWS serverles notifications center to send messages in multiple communication channels.